### PR TITLE
UI bug fix

### DIFF
--- a/FavLocations/MainWindow.xaml.cs
+++ b/FavLocations/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace FavLocations
         private List<string> pathsList = Properties.Settings.Default.pathsList == null? new() : Properties.Settings.Default.pathsList.Cast<string>().ToList() ;
         private List<string> namesList= Properties.Settings.Default.namesList == null ? new() : Properties.Settings.Default.namesList.Cast<string>().ToList();
 
+        private bool whitemode = true; //checks whether the application is currently in whitemode or dark mode
        
         public MainWindow()
         {
@@ -52,7 +53,15 @@ namespace FavLocations
             if (returnToInitialStat_pathBox)
             {
                 pathBox.Text = "";
-                pathBox.Foreground =Brushes.Black;
+                if (whitemode)
+                {
+                    pathBox.Foreground = Brushes.Black;
+                }
+                else
+                {
+                    pathBox.Foreground = Brushes.White;
+                }
+
                 if (nameBox.Text == "Name this Location Here")
                 {
                     nameBox.Text = "";
@@ -78,7 +87,14 @@ namespace FavLocations
                     pathBox.Text = "";
                 }
                 nameBox.Text = "";
-                nameBox.Foreground =Brushes.Black;
+                if (whitemode)
+                {
+                    nameBox.Foreground = Brushes.Black;
+                }
+                else
+                {
+                    nameBox.Foreground = Brushes.White;
+                }
                 returnToInitialStat_nameBox = false;
             }
         }
@@ -576,11 +592,13 @@ namespace FavLocations
         }
         private void TurnToDarkMode()
         {
+            whitemode = false;
             mainWindow.Background = new SolidColorBrush(Colors.Black);
             TurnElementsToDark();
         }
         private void TurnToLightMode()
         {
+            whitemode = true;
             mainWindow.Background = new SolidColorBrush(Colors.White);
             TurnElementsToLight();
         }


### PR DESCRIPTION
Hey i have found a bug in your UI. Changing the application to white mode from dark mode the text inside path textbox and name textbox doesn't update color and remains black 
![bug_black_text](https://user-images.githubusercontent.com/62183975/149950311-198ee607-69fd-4a04-a3c1-5f73724a961d.jpg)
As you can see the text that i highlighted in blue.
This is because when the control gets focus for both name textbox and path textbox the colour was set to be black inside the management page event section.
![bug_line_namebox](https://user-images.githubusercontent.com/62183975/149950765-43f976d1-789f-46ac-9620-d64ac3ce4f65.jpg)
![bug_line_pathbox](https://user-images.githubusercontent.com/62183975/149950784-f5c0cb00-dc57-4d78-bf23-32ce1436e2a0.jpg)
I have fixed this by creating a boolean that checks whether the application is currently in dark mode or white mode and updates the path text box and name text box accordingly.
Please check my fix.